### PR TITLE
Fix early grouping before preferences load

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,8 @@
 // ──────────────────────────
 
 // A — Preferences -------------------------------------------------
-let enabled = true;
+// Use 'null' before preferences load to avoid acting on stale defaults.
+let enabled = null;
 let placement = 'after'; // 'after' | 'first' | 'last'
 let enableStandardTabShortcut = true; // New preference for the shortcut
 


### PR DESCRIPTION
## Summary
- avoid grouping tabs until preferences have loaded

## Testing
- `npx web-ext lint --boring`

------
https://chatgpt.com/codex/tasks/task_e_6841de2fbb64832aad841852e320b8fb