### PR TITLE
Improve active tab tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![Firefox 138+](https://img.shields.io/badge/firefox-138%2B-orange)](https://addons.mozilla.org/en-US/firefox/addon/new-tab-same-group/)
 [![Get it on AMO](https://img.shields.io/amo/v/new-tab-same-group?label=Get%20on%20AMO)](https://addons.mozilla.org/en-US/firefox/addon/new-tab-same-group/)
-**Version 1.3.0**
+**Version 1.3.1**
 
 **New Tab Same Group** is a Firefox extension that improves tab organization by automatically inserting new tabs into the same group as your current active tab — right after it, at the beginning, or at the end of the group, based on your preference.
 This extension only works with **native tab grouping** (Firefox 138+).
@@ -18,7 +18,7 @@ This extension only works with **native tab grouping** (Firefox 138+).
   - **At the beginning** of the current group
   - **At the end** of the current group
 - ⌨️ **NEW:** Optional keyboard shortcut (`Alt+Shift+T` by default) to open a new tab in the standard Firefox way, without applying grouping logic. This can be toggled in the extension's options.
-- 🧠 Smart tracking of the source tab to ensure consistent behavior
+- 🧠 Smarter tracking of the active tab for reliable grouping across windows
 - 🖤 Fully supports Firefox's native tab groups
 - 🔒 Zero tracking, zero external dependencies
 - 🧩 Works perfectly with both **vertical tab layouts** and **classic horizontal tabs**

--- a/background.js
+++ b/background.js
@@ -37,6 +37,32 @@ chrome.storage.onChanged.addListener((changes) => {
 
 // B — Track the last active tab -----------------------------------
 let lastActiveTab = null;
+
+// Initialize lastActiveTab with the current active tab in the last focused window
+chrome.tabs.query({ active: true, lastFocusedWindow: true }).then(tabs => {
+  if (tabs.length > 0) {
+    lastActiveTab = tabs[0];
+  }
+}).catch(e => {
+  console.error('Error initializing active tab:', e);
+});
+
+// Update lastActiveTab whenever the focused window changes
+chrome.windows.onFocusChanged.addListener(async (windowId) => {
+  if (windowId === chrome.windows.WINDOW_ID_NONE) {
+    lastActiveTab = null;
+    return;
+  }
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, windowId });
+    if (tab) {
+      lastActiveTab = tab;
+    }
+  } catch (e) {
+    console.error('onFocusChanged error:', e);
+  }
+});
+
 chrome.tabs.onActivated.addListener(async ({ tabId }) => {
   try {
     lastActiveTab = await chrome.tabs.get(tabId);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "New Tab Same Group",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Automatically adds new tabs to the same group as the active tab in Firefox.",
   "icons": {
     "128": "images/new-tab-same-group-128.png"


### PR DESCRIPTION
## Summary
- improve tracking of the last active tab on startup and when changing windows
- bump extension version to 1.3.1 in manifest and README
- document smarter tracking in README

## Testing
- `npx web-ext lint` *(fails: asks to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6841e41588dc832aa26a53ff6b2dec04