### PR TITLE
Add shortcut settings link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can customize this shortcut via Firefox's "Manage Extension Shortcuts" menu:
 2. Click the gear icon ⚙️ in the top-right corner.
 3. Select "Manage Extension Shortcuts".
 4. Find "New Tab Same Group" and customize the "Open a standard new tab (not managed by the extension)" shortcut.
+   You can also open this settings page directly from the extension's options by clicking the **Customize shortcut…** link.
 
 ---
 

--- a/options.css
+++ b/options.css
@@ -78,3 +78,12 @@ kbd {
   white-space: nowrap;
   margin: 0 2px;
 }
+
+/* Shortcut settings link */
+#editShortcutLink {
+  color: #4ea1f3;
+  text-decoration: none;
+}
+#editShortcutLink:hover {
+  text-decoration: underline;
+}

--- a/options.html
+++ b/options.html
@@ -40,6 +40,7 @@
     <div class="label">
       Enable shortcut <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>
       <small>To open a standard new tab (ungrouped)</small>
+      <small><a href="#" id="editShortcutLink">Customize shortcut…</a></small>
     </div>
     <label class="switch">
       <input type="checkbox" id="enableStandardShortcut">

--- a/options.js
+++ b/options.js
@@ -4,6 +4,7 @@ const placementCard = document.getElementById('placementCard');
 const radios = document.querySelectorAll('input[name="placement"]');
 
 const enableStandardShortcutCB = document.getElementById('enableStandardShortcut');
+const editShortcutLink = document.getElementById('editShortcutLink');
 // No need to target standardShortcutCard for now, unless we want to disable it
 // based on another option, which is not the case here.
 
@@ -46,6 +47,17 @@ radios.forEach(radio => {
 // Listener for standard shortcut enable/disable
 enableStandardShortcutCB.addEventListener('change', () => {
   chrome.storage.sync.set({ enableStandardTabShortcut: enableStandardShortcutCB.checked });
+});
+
+// Open Firefox's Manage Extension Shortcuts page
+editShortcutLink.addEventListener('click', (e) => {
+  e.preventDefault();
+  if (chrome.commands && typeof chrome.commands.openShortcutSettings === 'function') {
+    chrome.commands.openShortcutSettings();
+  } else {
+    // Fallback: open about:addons where shortcuts can be managed
+    chrome.tabs.create({ url: 'about:addons' });
+  }
 });
 
 // Function to manage visibility and state of the placement card


### PR DESCRIPTION
## Summary
- link to Firefox's shortcut settings from options page
- handle link in options script
- style shortcut link
- document new shortcut link in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e665368c832abfd14709e66be479